### PR TITLE
ユーザー小説一覧のタグ絞り込みページでミュートを適用すると、全ての作品が表示されなくなるバグを修正

### DIFF
--- a/src/utils/filterFirstPageWorks.ts
+++ b/src/utils/filterFirstPageWorks.ts
@@ -73,7 +73,7 @@ export const filterFirstPageWorks = async (
 
 	if (PAGE_REGEX.userIllust.test(pathName) || PAGE_REGEX.userNovel.test(pathName)) {
 		// ユーザー一覧のタグ絞りの場合
-		const userTag = /\/users\/\d+\/(illustrations|manga|artworks)\/.+/;
+		const userTag = /\/users\/\d+\/(illustrations|manga|artworks|novels)\/.+/;
 		if (userTag.test(pathName)) {
 			data.body.works = data.body.works.filter((work: Work) => filterMuted(work, mutedItems));
 		} else {


### PR DESCRIPTION
fix #41